### PR TITLE
Refactor variable names to be more adequate

### DIFF
--- a/presence-s.lua
+++ b/presence-s.lua
@@ -30,8 +30,8 @@ local application = {
 
 addEventHandler("onPlayerResourceStart", root,
     function(theResource)
-        if (theResource == getThisResource()) then
-            triggerClientEvent(source, "addPlayerRichPresence", resourceRoot, application);
+        if (theResource == resource) then
+            triggerClientEvent(source, "addPlayerRichPresence", source, application);
         end
     end
 );

--- a/presence-s.lua
+++ b/presence-s.lua
@@ -7,13 +7,11 @@
 
 local application = {
     id = "", -- Application ID
-
-    server = {
-        name = "Roman Store Inc.",
-        logo = "https://i.imgur.com/wkRCwhI.png",
-        max_slots = tonumber(getServerConfigSetting("maxplayers")),
-        description = "Melhor loja de resources do MTA:SA."
-    },
+    state = "Jogadores Online",
+    max_slots = tonumber(getServerConfigSetting("maxplayers")),
+    logo = "https://i.imgur.com/wkRCwhI.png",
+    logo_name = "Roman Store Inc.",
+    details = "Melhor loja de resources do MTA:SA."
 
     buttons = {
         [1] = {

--- a/presence.lua
+++ b/presence.lua
@@ -8,22 +8,22 @@ function setDiscordRichPresence()
     resetDiscordRichPresenceData();
     local connected = setDiscordApplicationID(application.id);
     if (connected) then
-        setDiscordRichPresencePartySize(#getElementsByType("player"), application['server'].max_slots);
+        setDiscordRichPresencePartySize(#getElementsByType("player"), application['max_slots']);
         if (application['buttons'][1].use) then setDiscordRichPresenceButton(1, application['buttons'][1].name, application['buttons'][1].link); end
         if (application['buttons'][2].use) then setDiscordRichPresenceButton(2, application['buttons'][2].name, application['buttons'][2].link); end
-        if (application['server']['description']:len() > 0) then setDiscordRichPresenceDetails(application['server'].description); end
-        setDiscordRichPresenceAsset(application['server'].logo, application['server'].name);
-        setDiscordRichPresenceState(application['server'].name);
+        if (application['details']:len() > 0) then setDiscordRichPresenceDetails(application['details']); end
+        setDiscordRichPresenceAsset(application['logo'], application['logo_name']);
+        setDiscordRichPresenceState(application['state']);
         setDiscordRichPresenceStartTime(1);
     end
 end
 
 addEvent("addPlayerRichPresence", true);
-addEventHandler("addPlayerRichPresence", resourceRoot,
+addEventHandler("addPlayerRichPresence", localPlayer,
     function(data)
         application = data;
         setDiscordRichPresence();
-    end
+    end, false
 );
 
 addEventHandler("onClientPlayerJoin", root, 
@@ -32,7 +32,7 @@ addEventHandler("onClientPlayerJoin", root,
             return;
         end
 
-        setDiscordRichPresencePartySize(#getElementsByType("player"), application['server'].max_slots);
+        setDiscordRichPresencePartySize(#getElementsByType("player"), application['max_slots']);
     end
 );
 
@@ -42,6 +42,6 @@ addEventHandler("onClientPlayerQuit", root,
             return;
         end
         
-        setDiscordRichPresencePartySize(#getElementsByType("player"), application['server'].max_slots);
+        setDiscordRichPresencePartySize(#getElementsByType("player"), application['max_slots']);
     end
 );


### PR DESCRIPTION
Changed some variable names like 'server name' to 'state', 'server description' to 'details' because they correspond better to the Discord Rich Presence client functions that it uses to set the strings.